### PR TITLE
Set domainNumber from config file

### DIFF
--- a/python/test.py
+++ b/python/test.py
@@ -106,6 +106,7 @@ def main():
 
   prms = msg.getParams()
   prms.self_id.portNumber = os.getpid()
+  prms.domainNumber = cfg.domainNumber()
   msg.updateParams(prms)
   id = pmc.USER_DESCRIPTION
   msg.setAction(pmc.GET, id)


### PR DESCRIPTION
The test.py program will fail if the system domainNumber is not the default, but is otherwise specified in the config file.  This change sets the domainNumber based on the value read from the config file.