### PR TITLE
Enable Python multithreading while executing SockBase functions

### DIFF
--- a/libpmc.i
+++ b/libpmc.i
@@ -10,7 +10,10 @@
 #ifdef SWIGPERL
 %module PmcLib
 #else /* Not Perl */
-%module pmc
+%module("threads"=1) pmc
+#ifdef SWIGPYTHON
+%nothread;
+#endif
 #endif /* SWIGPERL */
 %{
     #include "cfg.h"
@@ -81,7 +84,13 @@ list(SLAVE_RX_SYNC_TIMING_DATA_t)
 %include "ptp.h"
 %feature("notabstract") SockBase;
 %feature("notabstract") SockBaseIf;
+#ifdef SWIGPYTHON
+%thread;
+#endif
 %include "sock.h"
+#ifdef SWIGPYTHON
+%nothread;
+#endif
 %include "bin.h"
 %include "buf.h"
 %include "json.h"


### PR DESCRIPTION
Normally, SWIG locks the global interpreter lock while calling C++ functions from Python. That is not good for blocking IO operations (no other Python threads can do anything while the lock is locked).

I found this way to tell SWIG to release the lock while code is in the blocking function. The implementation is not optimal because it adds the unlocking/locking to all functions in sock.h, but I haven't found a more fine-grained way to achieve this (theoretically, it should be possible using `%feature("thread")` annotation for functions, but I did not have luck with it). SWIG docs say there is a slight performance penalty for the unlocking/locking, but that should be negligible for pmc use-case.

I'm also not sure if there are more blocking calls outside sock.h that would also benefit from this.